### PR TITLE
[api/v1alpha2]: Check for nil map when adding labels.

### DIFF
--- a/api/v1alpha3/labels.go
+++ b/api/v1alpha3/labels.go
@@ -75,6 +75,9 @@ func (in Labels) Difference(other Labels) Labels {
 // AddLabels adds (and overwrites) the current labels with the ones passed in.
 func (in Labels) AddLabels(other Labels) Labels {
 	for key, value := range other {
+		if in == nil {
+			in = make(map[string]string, len(other))
+		}
 		in[key] = value
 	}
 	return in


### PR DESCRIPTION
Fixes panic when creating machine with additional labels.